### PR TITLE
Added positional offsets to bar locations for each layout

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/config/forge/ClientContainer.java
+++ b/src/main/java/com/robertx22/mine_and_slash/config/forge/ClientContainer.java
@@ -43,11 +43,6 @@ public class ClientContainer {
         builder.comment("Client Settings")
             .push(NAME);
 
-        LEFT_VANILLA_LIKE_BARS_Y__POS_ADJUST = builder.comment(".")
-            .defineInRange("LEFT_VANILLA_LIKE_BARS_Y__POS_ADJUST", 0, -10000, 10000);
-        RIGHT_VANILLA_LIKE_BARS_Y__POS_ADJUST = builder.comment(".")
-            .defineInRange("RIGHT_VANILLA_LIKE_BARS_Y__POS_ADJUST", 0, -10000, 10000);
-
         neatConfig = builder.configure(NeatConfig::new)
             .getLeft();
         dmgParticleConfig = builder.configure(DmgParticleConfig::new)
@@ -86,6 +81,74 @@ public class ClientContainer {
         PLAYER_GUI_TYPE = builder.comment(".")
             .translation("mmorpg.config.player_gui_overlay_type")
             .defineEnum("PLAYER_GUI_TYPE", PlayerGUIs.Bottom_Middle_Corners);
+
+        builder.pop();
+
+        builder.comment("Azure Top Left Settings")
+            .push("Azure Bars");
+
+        AZURE_Y_POS_ADJUST = builder.comment(".")
+            .defineInRange("AZURE_Y_POS_ADJUST", 0, -10000, 10000);
+        AZURE_X_POS_ADJUST = builder.comment(".")
+            .defineInRange("AZURE_X_POS_ADJUST", 0, -10000, 10000);
+
+        builder.pop();
+
+        builder.comment("Bottom Middle Corner Bar Settings")
+            .push("Bottom Middle Corner Bars");
+
+        BMC_LEFT_Y_POS_ADJUST = builder.comment(".")
+            .defineInRange("BMC_LEFT_Y_POS_ADJUST", 0, -10000, 10000);
+        BMC_LEFT_X_POS_ADJUST = builder.comment(".")
+            .defineInRange("BMC_LEFT_X_POS_ADJUST", 0, -10000, 10000);
+        BMC_RIGHT_Y_POS_ADJUST = builder.comment(".")
+            .defineInRange("BMC_RIGHT_Y_POS_ADJUST", 0, -10000, 10000);
+        BMC_RIGHT_X_POS_ADJUST = builder.comment(".")
+            .defineInRange("BMC_RIGHT_X_POS_ADJUST", 0, -10000, 10000);
+
+        builder.pop();
+
+        builder.comment("Bottom Middle Bar Settings")
+            .push("Bottom Middle Bars");
+
+        BM_LEFT_Y_POS_ADJUST = builder.comment(".")
+            .defineInRange("BM_LEFT_Y_POS_ADJUST", 0, -10000, 10000);
+        BM_LEFT_X_POS_ADJUST = builder.comment(".")
+            .defineInRange("BM_LEFT_X_POS_ADJUST", 0, -10000, 10000);
+        BM_RIGHT_Y_POS_ADJUST = builder.comment(".")
+            .defineInRange("BM_RIGHT_Y_POS_ADJUST", 0, -10000, 10000);
+        BM_RIGHT_X_POS_ADJUST = builder.comment(".")
+            .defineInRange("BM_RIGHT_X_POS_ADJUST", 0, -10000, 10000);
+
+        builder.pop();
+
+        builder.comment("Middle Bar Settings")
+            .push("Middle Bars");
+
+        MIDDLE_Y_POS_ADJUST = builder.comment(".")
+            .defineInRange("MIDDLE_Y_POS_ADJUST", 0, -10000, 10000);
+        MIDDLE_X_POS_ADJUST = builder.comment(".")
+            .defineInRange("MIDDLE_X_POS_ADJUST", 0, -10000, 10000);
+
+        builder.pop();
+
+        builder.comment("Top Left Settings")
+            .push("Top Left Bars");
+
+        TOP_LEFT_Y_POS_ADJUST = builder.comment(".")
+            .defineInRange("TOP_LEFT_Y_POS_ADJUST", 0, -10000, 10000);
+        TOP_LEFT_X_POS_ADJUST = builder.comment(".")
+            .defineInRange("TOP_LEFT_X_POS_ADJUST", 0, -10000, 10000);
+
+        builder.pop();
+
+        builder.comment("Vanilla Bar Settings")
+            .push("Vanilla Bars");
+
+        LEFT_VANILLA_LIKE_BARS_Y__POS_ADJUST = builder.comment(".")
+            .defineInRange("LEFT_VANILLA_LIKE_BARS_Y__POS_ADJUST", 0, -10000, 10000);
+        RIGHT_VANILLA_LIKE_BARS_Y__POS_ADJUST = builder.comment(".")
+            .defineInRange("RIGHT_VANILLA_LIKE_BARS_Y__POS_ADJUST", 0, -10000, 10000);
 
         builder.pop();
     }

--- a/src/main/java/com/robertx22/mine_and_slash/config/forge/ClientContainer.java
+++ b/src/main/java/com/robertx22/mine_and_slash/config/forge/ClientContainer.java
@@ -8,6 +8,8 @@ import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.BooleanValue;
 import net.minecraftforge.common.ForgeConfigSpec.EnumValue;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import org.apache.commons.lang3.tuple.Pair;
 
 @Mod.EventBusSubscriber(modid = Ref.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
@@ -43,10 +45,10 @@ public class ClientContainer {
     public ForgeConfigSpec.IntValue AZURE_X_POS_ADJUST;
     public ForgeConfigSpec.IntValue AZURE_Y_POS_ADJUST;
 
-    public ForgeConfigSpec.IntValue BMC_LEFT_Y_POS_ADJUST;
     public ForgeConfigSpec.IntValue BMC_LEFT_X_POS_ADJUST;
-    public ForgeConfigSpec.IntValue BMC_RIGHT_Y_POS_ADJUST;
+    public ForgeConfigSpec.IntValue BMC_LEFT_Y_POS_ADJUST;
     public ForgeConfigSpec.IntValue BMC_RIGHT_X_POS_ADJUST;
+    public ForgeConfigSpec.IntValue BMC_RIGHT_Y_POS_ADJUST;
     
     public ForgeConfigSpec.IntValue MIDDLE_Y_POS_ADJUST;
     
@@ -139,23 +141,23 @@ public class ClientContainer {
             .push("Azure Bars");
 
         AZURE_Y_POS_ADJUST = builder.comment("Adjusts All Bars Downwards")
-            .defineInRange("AZURE_Y_POS_ADJUST", 0, 0, 10000);
+            .defineInRange("AZURE_Y_POS_ADJUST", 0, 0, 1000);
         AZURE_X_POS_ADJUST = builder.comment("Adjusts All Bars Rightwards")
-            .defineInRange("AZURE_X_POS_ADJUST", 0, 0, 10000);
+            .defineInRange("AZURE_X_POS_ADJUST", 0, 0, 1000);
 
         builder.pop();
 
         builder.comment("Bottom Middle Corner Bar Settings")
             .push("Bottom Middle Corner Bars");
 
-        BMC_LEFT_Y_POS_ADJUST = builder.comment("Adjusts HP/XP Upwards")
-            .defineInRange("BMC_LEFT_Y_POS_ADJUST", 0, 0, 10000);
         BMC_LEFT_X_POS_ADJUST = builder.comment("Adjusts HP/XP Leftwards")
-            .defineInRange("BMC_LEFT_X_POS_ADJUST", 0, 0, 10000);
-        BMC_RIGHT_Y_POS_ADJUST = builder.comment("Adjusts Mana/Energy Upwards")
-            .defineInRange("BMC_RIGHT_Y_POS_ADJUST", 0, 0, 10000);
+            .defineInRange("BMC_LEFT_X_POS_ADJUST", 0, 0, 1000);
+        BMC_LEFT_Y_POS_ADJUST = builder.comment("Adjusts HP/XP Upwards")
+            .defineInRange("BMC_LEFT_Y_POS_ADJUST", 0, 0, 1000);
         BMC_RIGHT_X_POS_ADJUST = builder.comment("Adjusts Mana/Energy Rightwards")
-            .defineInRange("BMC_RIGHT_X_POS_ADJUST", 0, 0, 10000);
+            .defineInRange("BMC_RIGHT_X_POS_ADJUST", 0, 0, 1000);
+        BMC_RIGHT_Y_POS_ADJUST = builder.comment("Adjusts Mana/Energy Upwards")
+            .defineInRange("BMC_RIGHT_Y_POS_ADJUST", 0, 0, 1000);
 
         builder.pop();
 
@@ -163,7 +165,7 @@ public class ClientContainer {
             .push("Middle Bars");
 
         MIDDLE_Y_POS_ADJUST = builder.comment("Adjusts All Bars Upwards")
-            .defineInRange("MIDDLE_Y_POS_ADJUST", 0, 0, 10000);
+            .defineInRange("MIDDLE_Y_POS_ADJUST", 0, 0, 1000);
 
         builder.pop();
 
@@ -171,9 +173,9 @@ public class ClientContainer {
             .push("Top Left Bars");
 
         TOPLEFT_Y_POS_ADJUST = builder.comment("Adjusts All Bars Downwards")
-            .defineInRange("TOPLEFT_Y_POS_ADJUST", 0, 0, 10000);
+            .defineInRange("TOPLEFT_Y_POS_ADJUST", 0, 0, 1000);
         TOPLEFT_X_POS_ADJUST = builder.comment("Adjusts All Bars Rightwards")
-            .defineInRange("TOPLEFT_X_POS_ADJUST", 0, 0, 10000);
+            .defineInRange("TOPLEFT_X_POS_ADJUST", 0, 0, 1000);
 
         builder.pop();
 
@@ -181,9 +183,9 @@ public class ClientContainer {
             .push("Vanilla Bars");
 
         LEFT_VANILLA_LIKE_BARS_Y__POS_ADJUST = builder.comment(".")
-            .defineInRange("LEFT_VANILLA_LIKE_BARS_Y__POS_ADJUST", 0, 0, 10000);
+            .defineInRange("LEFT_VANILLA_LIKE_BARS_Y__POS_ADJUST", 0, 0, 1000);
         RIGHT_VANILLA_LIKE_BARS_Y__POS_ADJUST = builder.comment(".")
-            .defineInRange("RIGHT_VANILLA_LIKE_BARS_Y__POS_ADJUST", 0, 0, 10000);
+            .defineInRange("RIGHT_VANILLA_LIKE_BARS_Y__POS_ADJUST", 0, 0, 1000);
 
         builder.pop();
     }

--- a/src/main/java/com/robertx22/mine_and_slash/config/forge/ClientContainer.java
+++ b/src/main/java/com/robertx22/mine_and_slash/config/forge/ClientContainer.java
@@ -3,11 +3,14 @@ package com.robertx22.mine_and_slash.config.forge;
 import com.robertx22.mine_and_slash.a_libraries.neat_mob_overlay.NeatConfig;
 import com.robertx22.mine_and_slash.config.forge.parts.DmgParticleConfig;
 import com.robertx22.mine_and_slash.uncommon.enumclasses.PlayerGUIs;
+import com.robertx22.mine_and_slash.mmorpg.Ref;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.BooleanValue;
 import net.minecraftforge.common.ForgeConfigSpec.EnumValue;
+import net.minecraftforge.fml.common.Mod;
 import org.apache.commons.lang3.tuple.Pair;
 
+@Mod.EventBusSubscriber(modid = Ref.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class ClientContainer {
 
     public static final String NAME = "CLIENT";
@@ -37,7 +40,55 @@ public class ClientContainer {
     public ForgeConfigSpec.IntValue LEFT_VANILLA_LIKE_BARS_Y__POS_ADJUST;
     public ForgeConfigSpec.IntValue RIGHT_VANILLA_LIKE_BARS_Y__POS_ADJUST;
 
+    public ForgeConfigSpec.IntValue AZURE_X_POS_ADJUST;
+    public ForgeConfigSpec.IntValue AZURE_Y_POS_ADJUST;
+
+    public ForgeConfigSpec.IntValue BMC_LEFT_Y_POS_ADJUST;
+    public ForgeConfigSpec.IntValue BMC_LEFT_X_POS_ADJUST;
+    public ForgeConfigSpec.IntValue BMC_RIGHT_Y_POS_ADJUST;
+    public ForgeConfigSpec.IntValue BMC_RIGHT_X_POS_ADJUST;
+    
+    public ForgeConfigSpec.IntValue MIDDLE_Y_POS_ADJUST;
+    
+    public ForgeConfigSpec.IntValue TOPLEFT_X_POS_ADJUST;
+    public ForgeConfigSpec.IntValue TOPLEFT_Y_POS_ADJUST;
+
     public EnumValue<PlayerGUIs> PLAYER_GUI_TYPE;
+
+    public static int AzureXAdjust;
+    public static int AzureYAdjust;
+
+    public static int BMCLeftXAdjust;
+    public static int BMCLeftYAdjust;
+    public static int BMCRightXAdjust;
+    public static int BMCRightYAdjust;
+
+    public static int MiddleYAdjust;
+
+    public static int TopLeftXAdjust;
+    public static int TopLeftYAdjust;
+
+	@SubscribeEvent
+	public static void onModConfigEvent(final ModConfig.ModConfigEvent configEvent) {
+		if (configEvent.getConfig().getSpec() == ClientContainer.spec) {
+			bakeConfig();
+		}
+	}
+
+	public static void bakeConfig() {
+        AzureXAdjust = INSTANCE.AZURE_X_POS_ADJUST.get();
+        AzureYAdjust = INSTANCE.AZURE_Y_POS_ADJUST.get();
+
+        BMCLeftXAdjust = INSTANCE.BMC_LEFT_X_POS_ADJUST.get();
+        BMCLeftYAdjust = INSTANCE.BMC_LEFT_Y_POS_ADJUST.get();
+        BMCRightXAdjust = INSTANCE.BMC_RIGHT_X_POS_ADJUST.get();
+        BMCRightYAdjust = INSTANCE.BMC_RIGHT_Y_POS_ADJUST.get();
+
+        MiddleYAdjust = INSTANCE.MIDDLE_Y_POS_ADJUST.get();
+
+        TopLeftXAdjust = INSTANCE.TOPLEFT_X_POS_ADJUST.get();
+        TopLeftYAdjust = INSTANCE.TOPLEFT_Y_POS_ADJUST.get();
+	}
 
     ClientContainer(ForgeConfigSpec.Builder builder) {
         builder.comment("Client Settings")
@@ -87,58 +138,42 @@ public class ClientContainer {
         builder.comment("Azure Top Left Settings")
             .push("Azure Bars");
 
-        AZURE_Y_POS_ADJUST = builder.comment(".")
-            .defineInRange("AZURE_Y_POS_ADJUST", 0, -10000, 10000);
-        AZURE_X_POS_ADJUST = builder.comment(".")
-            .defineInRange("AZURE_X_POS_ADJUST", 0, -10000, 10000);
+        AZURE_Y_POS_ADJUST = builder.comment("Adjusts All Bars Downwards")
+            .defineInRange("AZURE_Y_POS_ADJUST", 0, 0, 10000);
+        AZURE_X_POS_ADJUST = builder.comment("Adjusts All Bars Rightwards")
+            .defineInRange("AZURE_X_POS_ADJUST", 0, 0, 10000);
 
         builder.pop();
 
         builder.comment("Bottom Middle Corner Bar Settings")
             .push("Bottom Middle Corner Bars");
 
-        BMC_LEFT_Y_POS_ADJUST = builder.comment(".")
-            .defineInRange("BMC_LEFT_Y_POS_ADJUST", 0, -10000, 10000);
-        BMC_LEFT_X_POS_ADJUST = builder.comment(".")
-            .defineInRange("BMC_LEFT_X_POS_ADJUST", 0, -10000, 10000);
-        BMC_RIGHT_Y_POS_ADJUST = builder.comment(".")
-            .defineInRange("BMC_RIGHT_Y_POS_ADJUST", 0, -10000, 10000);
-        BMC_RIGHT_X_POS_ADJUST = builder.comment(".")
-            .defineInRange("BMC_RIGHT_X_POS_ADJUST", 0, -10000, 10000);
-
-        builder.pop();
-
-        builder.comment("Bottom Middle Bar Settings")
-            .push("Bottom Middle Bars");
-
-        BM_LEFT_Y_POS_ADJUST = builder.comment(".")
-            .defineInRange("BM_LEFT_Y_POS_ADJUST", 0, -10000, 10000);
-        BM_LEFT_X_POS_ADJUST = builder.comment(".")
-            .defineInRange("BM_LEFT_X_POS_ADJUST", 0, -10000, 10000);
-        BM_RIGHT_Y_POS_ADJUST = builder.comment(".")
-            .defineInRange("BM_RIGHT_Y_POS_ADJUST", 0, -10000, 10000);
-        BM_RIGHT_X_POS_ADJUST = builder.comment(".")
-            .defineInRange("BM_RIGHT_X_POS_ADJUST", 0, -10000, 10000);
+        BMC_LEFT_Y_POS_ADJUST = builder.comment("Adjusts HP/XP Upwards")
+            .defineInRange("BMC_LEFT_Y_POS_ADJUST", 0, 0, 10000);
+        BMC_LEFT_X_POS_ADJUST = builder.comment("Adjusts HP/XP Leftwards")
+            .defineInRange("BMC_LEFT_X_POS_ADJUST", 0, 0, 10000);
+        BMC_RIGHT_Y_POS_ADJUST = builder.comment("Adjusts Mana/Energy Upwards")
+            .defineInRange("BMC_RIGHT_Y_POS_ADJUST", 0, 0, 10000);
+        BMC_RIGHT_X_POS_ADJUST = builder.comment("Adjusts Mana/Energy Rightwards")
+            .defineInRange("BMC_RIGHT_X_POS_ADJUST", 0, 0, 10000);
 
         builder.pop();
 
         builder.comment("Middle Bar Settings")
             .push("Middle Bars");
 
-        MIDDLE_Y_POS_ADJUST = builder.comment(".")
-            .defineInRange("MIDDLE_Y_POS_ADJUST", 0, -10000, 10000);
-        MIDDLE_X_POS_ADJUST = builder.comment(".")
-            .defineInRange("MIDDLE_X_POS_ADJUST", 0, -10000, 10000);
+        MIDDLE_Y_POS_ADJUST = builder.comment("Adjusts All Bars Upwards")
+            .defineInRange("MIDDLE_Y_POS_ADJUST", 0, 0, 10000);
 
         builder.pop();
 
         builder.comment("Top Left Settings")
             .push("Top Left Bars");
 
-        TOP_LEFT_Y_POS_ADJUST = builder.comment(".")
-            .defineInRange("TOP_LEFT_Y_POS_ADJUST", 0, -10000, 10000);
-        TOP_LEFT_X_POS_ADJUST = builder.comment(".")
-            .defineInRange("TOP_LEFT_X_POS_ADJUST", 0, -10000, 10000);
+        TOPLEFT_Y_POS_ADJUST = builder.comment("Adjusts All Bars Downwards")
+            .defineInRange("TOPLEFT_Y_POS_ADJUST", 0, 0, 10000);
+        TOPLEFT_X_POS_ADJUST = builder.comment("Adjusts All Bars Rightwards")
+            .defineInRange("TOPLEFT_X_POS_ADJUST", 0, 0, 10000);
 
         builder.pop();
 
@@ -146,9 +181,9 @@ public class ClientContainer {
             .push("Vanilla Bars");
 
         LEFT_VANILLA_LIKE_BARS_Y__POS_ADJUST = builder.comment(".")
-            .defineInRange("LEFT_VANILLA_LIKE_BARS_Y__POS_ADJUST", 0, -10000, 10000);
+            .defineInRange("LEFT_VANILLA_LIKE_BARS_Y__POS_ADJUST", 0, 0, 10000);
         RIGHT_VANILLA_LIKE_BARS_Y__POS_ADJUST = builder.comment(".")
-            .defineInRange("RIGHT_VANILLA_LIKE_BARS_Y__POS_ADJUST", 0, -10000, 10000);
+            .defineInRange("RIGHT_VANILLA_LIKE_BARS_Y__POS_ADJUST", 0, 0, 10000);
 
         builder.pop();
     }

--- a/src/main/java/com/robertx22/mine_and_slash/gui/overlays/bar_overlays/types/AzureTopLeftOverlay.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/overlays/bar_overlays/types/AzureTopLeftOverlay.java
@@ -1,6 +1,7 @@
 package com.robertx22.mine_and_slash.gui.overlays.bar_overlays.types;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.robertx22.mine_and_slash.config.forge.ClientContainer;
 import com.robertx22.mine_and_slash.saveclasses.Unit;
 import com.robertx22.mine_and_slash.uncommon.capability.entity.EntityCap.UnitData;
 import com.robertx22.mine_and_slash.uncommon.utilityclasses.NumberUtils;
@@ -14,8 +15,8 @@ import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import java.awt.*;
 
 public class AzureTopLeftOverlay {
-    int xPos = 2;
-    int yPos = 4;
+    int xPos = 2 + ClientContainer.AzureXAdjust;
+    int yPos = 4 + ClientContainer.AzureYAdjust;
 
     public final ResourceLocation azuremanatexturepath = new ResourceLocation(
         "mmorpg", "textures/gui/overlay/mana_bar_azure.png");
@@ -133,35 +134,35 @@ public class AzureTopLeftOverlay {
 
         Unit unit = data.getUnit();
 
-        yPos = 2;
+        yPos = 2 + ClientContainer.AzureYAdjust;
 
         float scale = 1F;
 
         RenderSystem.scalef(scale, scale, scale);
 
-        xPos = 3;
-        yPos = 1;
+        xPos = 3 + ClientContainer.AzureXAdjust;
+        yPos = 1 + ClientContainer.AzureYAdjust;
         DrawUI(mc, gui, azurehudtexturepath, Type.LVL, data, xPos, yPos);
 
-        xPos = 59;
-        yPos = 4;
+        xPos = 59 + ClientContainer.AzureXAdjust;
+        yPos = 4 + ClientContainer.AzureYAdjust;
         DrawBar(mc, gui, azurehealthtexturepath, unit.health()
                 .CurrentValue(mc.player, unit), unit.healthData()
                 .getAverageValue(),
             Type.HP, data, xPos, yPos
         );
-        xPos = 59;
+        xPos = 59 + ClientContainer.AzureXAdjust;
         yPos += 11;
 
         DrawBar(mc, gui, azuremanatexturepath, data.getCurrentMana(), unit.manaData()
             .getAverageValue(), Type.MANA, data, xPos, yPos);
-        xPos = 59;
+        xPos = 59 + ClientContainer.AzureXAdjust;
         yPos += 11;
         DrawBar(mc, gui, azureenergytexturepath, data.getCurrentEnergy(), unit.energyData()
                 .getAverageValue(), Type.ENE, data, xPos,
             yPos
         );
-        xPos = 59;
+        xPos = 59 + ClientContainer.AzureXAdjust;
         yPos += 11;
         DrawBar(mc, gui, azureexperiencetexturepath, data.getExp(), data.getExpRequiredForLevelUp(), Type.EXP, data,
             xPos, yPos

--- a/src/main/java/com/robertx22/mine_and_slash/gui/overlays/bar_overlays/types/BottomMiddleCornersOverlay.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/overlays/bar_overlays/types/BottomMiddleCornersOverlay.java
@@ -1,6 +1,7 @@
 package com.robertx22.mine_and_slash.gui.overlays.bar_overlays.types;
 
 import com.robertx22.mine_and_slash.gui.overlays.bar_overlays.bases.BaseBarsOverlay;
+import com.robertx22.mine_and_slash.config.forge.ClientContainer;
 import com.robertx22.mine_and_slash.saveclasses.Unit;
 import com.robertx22.mine_and_slash.uncommon.capability.entity.EntityCap.UnitData;
 import net.minecraft.client.Minecraft;
@@ -9,7 +10,6 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 
 public class BottomMiddleCornersOverlay extends BaseBarsOverlay {
-
     private static final int X_OFFSET_OFFHAND = -20;
     private static final int X_OFFSET_NO_OFFHAND = 5;
 
@@ -26,30 +26,30 @@ public class BottomMiddleCornersOverlay extends BaseBarsOverlay {
         int height = mc.mainWindow.getScaledHeight();
         int width = mc.mainWindow.getScaledWidth();
 
-        int x = width / 2 + this.BAR_WIDTH - offsetx;
-        int y = height - offY - 1 - this.BAR_HEIGHT;
+        int x = width / 2 + this.BAR_WIDTH - offsetx + ClientContainer.BMCRightXAdjust;
+        int y = height - offY - 1 - this.BAR_HEIGHT - ClientContainer.BMCRightYAdjust;
 
         this.DrawBar(BarType.ENE, data, x, y);
 
         // MANA
-        x = width / 2 + this.BAR_WIDTH - offsetx;
-        y = height - offY;
+        x = width / 2 + this.BAR_WIDTH - offsetx + ClientContainer.BMCRightXAdjust;
+        y = height - offY - ClientContainer.BMCRightYAdjust;
 
         this.DrawBar(BarType.MANA, data, x, y);
 
         // MANA
 
         // HEALTH
-        x = width / 2 - this.BAR_WIDTH * 2 + offsetx;
-        y = height - offY - 1 - this.BAR_HEIGHT;
+        x = width / 2 - this.BAR_WIDTH * 2 + offsetx - ClientContainer.BMCLeftXAdjust;
+        y = height - offY - 1 - this.BAR_HEIGHT - ClientContainer.BMCLeftYAdjust;
 
         this.DrawBar(BarType.HP, data, x, y);
 
         // HEALTH
 
         // EXP
-        x = width / 2 - this.BAR_WIDTH * 2 + offsetx;
-        y = height - offY;
+        x = width / 2 - this.BAR_WIDTH * 2 + offsetx - ClientContainer.BMCLeftXAdjust;
+        y = height - offY - ClientContainer.BMCLeftYAdjust;
 
         this.DrawBar(BarType.EXP, data, x, y);
 

--- a/src/main/java/com/robertx22/mine_and_slash/gui/overlays/bar_overlays/types/MiddleOverlay.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/overlays/bar_overlays/types/MiddleOverlay.java
@@ -1,6 +1,7 @@
 package com.robertx22.mine_and_slash.gui.overlays.bar_overlays.types;
 
 import com.robertx22.mine_and_slash.gui.overlays.bar_overlays.bases.BaseBarsOverlay;
+import com.robertx22.mine_and_slash.config.forge.ClientContainer;
 import com.robertx22.mine_and_slash.saveclasses.Unit;
 import com.robertx22.mine_and_slash.uncommon.capability.entity.EntityCap.UnitData;
 import net.minecraft.client.Minecraft;
@@ -20,20 +21,20 @@ public class MiddleOverlay extends BaseBarsOverlay {
         int width = mc.mainWindow.getScaledWidth();
 
         int x = width / 2 + 5;
-        int y = height - 53;
+        int y = height - 53 - ClientContainer.MiddleYAdjust;
 
         this.DrawBar(BarType.ENE, data, x, y);
         // ENERGY
 
         // MANA
         x = width / 2 + 5;
-        y = height - 65;
+        y = height - 65 - ClientContainer.MiddleYAdjust;
         this.DrawBar(BarType.MANA, data, x, y);
         // MANA
 
         // HEALTH
         x = width / 2 - this.BAR_WIDTH;
-        y = height - 65;
+        y = height - 65 - ClientContainer.MiddleYAdjust;
 
         this.DrawBar(BarType.HP, data, x, y);
         // HEALTH
@@ -41,7 +42,7 @@ public class MiddleOverlay extends BaseBarsOverlay {
         // EXP
 
         x = width / 2 - this.BAR_WIDTH;
-        y = height - 53;
+        y = height - 53 - ClientContainer.MiddleYAdjust;
         this.DrawBar(BarType.EXP, data, x, y);
         // EXP
     }

--- a/src/main/java/com/robertx22/mine_and_slash/gui/overlays/bar_overlays/types/TopLeftOverlay.java
+++ b/src/main/java/com/robertx22/mine_and_slash/gui/overlays/bar_overlays/types/TopLeftOverlay.java
@@ -1,6 +1,7 @@
 package com.robertx22.mine_and_slash.gui.overlays.bar_overlays.types;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.robertx22.mine_and_slash.config.forge.ClientContainer;
 import com.robertx22.mine_and_slash.gui.overlays.bar_overlays.bases.BaseBarsOverlay;
 import com.robertx22.mine_and_slash.uncommon.capability.entity.EntityCap.UnitData;
 import net.minecraft.client.Minecraft;
@@ -9,13 +10,13 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 
 public class TopLeftOverlay extends BaseBarsOverlay {
-    int xPos = 2;
-    int yPos = 2;
+    int xPos = 2 + ClientContainer.TopLeftXAdjust;
+    int yPos = 2 + ClientContainer.TopLeftYAdjust;
 
     @Override
     public void Draw(AbstractGui gui, Minecraft mc, LivingEntity entity, RenderGameOverlayEvent event, UnitData data) {
 
-        yPos = 2;
+        yPos = 2 + ClientContainer.TopLeftYAdjust;
 
         float scale = 1F;
 


### PR DESCRIPTION
Added subcategories to the config for each bar layout and added x and y positional offsets for each where appropriate.

Middle does not have an X offset to keep it's goal of having a 'centered' bar. Top_Left can be used to create a non-centered bar anywhere on the screen.