### PR TITLE
Added maxEXPDistance Config and Functionality

### DIFF
--- a/src/main/java/com/robertx22/mine_and_slash/config/lvl_penalty/LvlPenaltyContainer.java
+++ b/src/main/java/com/robertx22/mine_and_slash/config/lvl_penalty/LvlPenaltyContainer.java
@@ -32,12 +32,14 @@ public class LvlPenaltyContainer implements ISlashRegistryInit {
         c.map.put(51, 0.025D);
         c.map.put(100, 0.01D);
 
+        c.maxEXPDistance = 100;
+
         return c;
 
     }
 
     private HashMap<Integer, Double> map = new HashMap<>();
-
+    private int maxEXPDistance = 100;
     public transient HashMap<Integer, Double> alreadyCalcMap = new HashMap<>();
 
     public Double getMultiForLevelDifference(int playerLvl, int mobLvl) {
@@ -58,6 +60,10 @@ public class LvlPenaltyContainer implements ISlashRegistryInit {
 
         return alreadyCalcMap.get(diff);
 
+    }
+
+    public int getMaxDistance(){
+        return this.maxEXPDistance;
     }
 
     @Override

--- a/src/main/java/com/robertx22/mine_and_slash/onevent/entity/OnMobDeathDrops.java
+++ b/src/main/java/com/robertx22/mine_and_slash/onevent/entity/OnMobDeathDrops.java
@@ -1,5 +1,7 @@
 package com.robertx22.mine_and_slash.onevent.entity;
 
+
+import com.robertx22.mine_and_slash.config.lvl_penalty.LvlPenaltyContainer;
 import com.robertx22.mine_and_slash.config.whole_mod_entity_configs.ModEntityConfig;
 import com.robertx22.mine_and_slash.db_lists.Rarities;
 import com.robertx22.mine_and_slash.loot.LootUtils;
@@ -147,7 +149,7 @@ public class OnMobDeathDrops {
             List<PlayerEntity> closeList = new ArrayList<>(); // list with only nearby members
 
             for (PlayerEntity p : list) {
-                if (p.world == killer.world && p.getDistance(killer) <= 100) {
+                if (p.world == killer.world && p.getDistance(killer) <= LvlPenaltyContainer.INSTANCE.getMaxDistance()) {
                     closeList.add(p);
                 }
             }


### PR DESCRIPTION
Added a maxEXPDistance config to the LvlPenalty Config (This seemed like the most appropriate place since it is at least related to levels) that now controls the maximum range a party can share experience (Replaced the hardcoded limit of 100, but retained that as the default value). 

My friends and I felt that this would be a useful change that would allow for a more customizable mapping experience. Having the distance be a configurable option with your desired default value seemed like it would be the best approach to take. Only problem I am aware of at the moment is that I am unaware of if you automatically update existing configs or not when you change them, so the new setting doesn't get added to existing configs automatically.